### PR TITLE
Reduce size of NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-src
-examples

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
     "ghooks": {
       "pre-commit": "npm run test"
     }
-  }
+  },
+  "files": []
 }


### PR DESCRIPTION
Despite the looks, `files: []` does not remove all files, it keeps package.json, readme.md and the file referenced by `main`, so basically all that is needed for this module.

It leaves out the rest:

- .babelrc
- .eslintrc.json
- .npmignore (I removed this one in the PR)
- .travis.yml
- test
- webpack.config-buildexamples.babel.js
- webpack.config-publish.babel.js
- webpack.config.babel.js

Thanks for your module!