### PR TITLE
Add id property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,8 @@ Name | Type | Default | Description
 min | number | 0 | Minimum slider value
 max | number | 100 | Maximum slider value
 step | number | 1  | Number inc/decremented when slider value is changed. The range of the slider (max - min) should be evenly divisible by this
-onChange | function | [NOOP](https://en.wikipedia.org/wiki/NOP) | Function to be called when the slider value changes - your slider will have no effect without this!
+id | string | `null` | Identifier that is passed to the onChange handler (see below)
+onChange | function | [NOOP](https://en.wikipedia.org/wiki/NOP) | Function to be called when the slider value changes - your slider will have no effect without this! See below for more information
 value | number | `props.defaultValue` | Set current value of slider
 defaultValue | number | 0 | Set initial value of slider
 vertical | boolean | `false` | Set slider to vertical when true
@@ -59,6 +60,21 @@ sliderColor | string | `#9E9E9E` | Color of slider
 trackColor | string | `#03A9F4` | Color of track and label
 thumbColor | string | `#fff` | Color of thumb
 customThumb | element | `undefined` | Pass in a single React element to use as your thumb, replacing the default
+
+## The onChange handler
+
+The onChange handler receives one argument: the new state of the component.
+It contains the following properties:
+
+Name | Type | Description
+---|---|---
+value|number|Current value
+min|number|Minimum value (from props)
+max|number|Maximum value (from props)
+range|number|Difference between `max` and `min`
+step|number|Step value (from props)
+ratio|number|Percentage of bar filled
+thumbSize|number|Thumb size value (from props)
 
 ## Commands
 

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -27,6 +27,7 @@ export default class Slider extends Component {
     thumbColor: PropTypes.string,
     sliderSize: PropTypes.number,
     thumbSize: PropTypes.number,
+    id: PropTypes.string,
   }
   static defaultProps = {
     min: 0,
@@ -43,6 +44,7 @@ export default class Slider extends Component {
     trackColor: '#009688',
     thumbColor: '#009688',
     sliderSize: 4,
+    id: null,
   }
   constructor(props) {
     super(props);
@@ -189,7 +191,7 @@ export default class Slider extends Component {
     if (props.thumbSize === undefined) {
       thumbSize = (this.props.disableThumb ? 0 : props.sliderSize * 2);
     }
-    const { min, max, step } = props;
+    const { min, max, step, id } = props;
     const range = max - min;
     const ratio = Math.max((value - min), 0) * 100 / (max - min);
     this.setState({
@@ -200,6 +202,7 @@ export default class Slider extends Component {
       step,
       ratio,
       thumbSize,
+      id,
     });
   }
   render() {
@@ -283,4 +286,3 @@ export default class Slider extends Component {
     );
   }
 }
-

--- a/test/ReactSimpleRange-test.js
+++ b/test/ReactSimpleRange-test.js
@@ -7,9 +7,16 @@ expect.extend(expectJSX);
 
 import ReactSimpleRange from '../src/index.js';
 
+let lastOnChangeCall = null;
+
+function onChange(state) {
+  lastOnChangeCall = state;
+}
+
 const wrapper = shallow(<ReactSimpleRange />);
 const wrapperWithValue = shallow(<ReactSimpleRange value={69} />);
 const wrapperWithDefaultValue = shallow(<ReactSimpleRange defaultValue={11} />);
+const wrapperWithOnChange = shallow(<ReactSimpleRange id="id" onChange={onChange} />);
 
 describe('ReactSimpleRange', () => {
   it('renders without exploding', () => {
@@ -29,6 +36,13 @@ describe('ReactSimpleRange', () => {
   });
   it('passes a specified value prop to SliderThumb as props.position', () => {
     expect(wrapperWithValue.find('SliderThumb').prop('position')).toEqual(69);
+  });
+  it('passes id to the onChange handler', () => {
+    lastOnChangeCall = null;
+    wrapperWithOnChange.instance().handleChange();
+    expect(lastOnChangeCall)
+      .toNotEqual(null)
+      .toInclude({ id: 'id' });
   });
 });
 
@@ -57,4 +71,3 @@ describe('SliderThumb', () => {
     expect(wrapperWithValue.find('SliderThumb').prop('position')).toEqual(69);
   });
 });
-


### PR DESCRIPTION
I had the problem that I couldn't easily identify different sliders on the same form in the onChange handler. I solved it by adding an `id` property that can be set via a prop and is returned in the state.