### PR TITLE
Fix npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "files": []
+  "files": ["lib/index.js"]
 }


### PR DESCRIPTION
For some reason npm isn't packing the main file. Force it.

I don't know why this happens so I also reported this to npm in npm/npm#17163. Maybe I overlooked something in the npm manual.

@tjallen 