### PR TITLE
style(npm): Remove all non-code files from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-src
-examples

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  }
+  },
+  "files": [
+    "lib/index.js"
+  ]
 }


### PR DESCRIPTION
This is a retry of #8. In the meantime package-lock.json was created, adding 216 useless kilobytes to the many deployments worldwide.